### PR TITLE
Fix: Enable segmented rendering for all initial SIFT reports

### DIFF
--- a/components/ChatMessageItem.tsx
+++ b/components/ChatMessageItem.tsx
@@ -119,7 +119,7 @@ ${groundingSourcesText}
 
 
   const renderContent = () => {
-    if (isInitialSIFTReport && originalQueryReportType === ReportType.FULL_CHECK && !isError && !isLoading) {
+    if (isInitialSIFTReport && !isError && !isLoading) {
       const parsedSections = parseReportIntoSections(text);
       if (parsedSections.length > 0) {
         return (


### PR DESCRIPTION
I modified the conditional statement in the `renderContent` function within `components/ChatMessageItem.tsx`.

The condition was changed from:
`if (isInitialSIFTReport && originalQueryReportType === ReportType.FULL_CHECK && !isError && !isLoading)` to:
`if (isInitialSIFTReport && !isError && !isLoading)`

This ensures that any initial AI-generated SIFT report, regardless of its specific `originalQueryReportType`, will be processed by `parseReportIntoSections` and rendered in the segmented UI format.

This fixes a bug where reports other than "FULL_CHECK" were displayed as a single block of text, and addresses issues like "Untitled Section" appearing due to incorrect parsing context.