### PR TITLE
feat: Use cached content for Gemini follow-up messages

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -611,7 +611,13 @@ const App: React.FC = () => {
         if (!currentChat) {
           throw new Error("Chat session not initialized for Gemini.");
         }
-        const stream = await currentChat.sendMessageStream({ message: messageText }); // Simple text message
+        let stream: GenerateContentResponse | undefined;
+        if (currentGeminiCacheName) {
+          const options = { tools: [{ cachedContent: { name: currentGeminiCacheName } }] };
+          stream = await currentChat.sendMessageStream({ message: messageText }, options);
+        } else {
+          stream = await currentChat.sendMessageStream({ message: messageText });
+        }
         let accumulatedText = "";
         let currentGroundingChunks: GroundingChunk[] = [];
         for await (const chunk of stream) {


### PR DESCRIPTION
I've modified `handleSendChatMessage` in `App.tsx` to leverage cached content when available for follow-up messages in Gemini chats.

If `currentGeminiCacheName` (the state variable holding the active cache name) exists, the `sendMessageStream` call will now include an `options` object. This allows the Gemini model to use the context from the cached initial SIFT report for more relevant and consistent follow-up responses. If no cache name is present, the call proceeds as before.