### PR TITLE
feat: Setup PostgreSQL with pgvector, hstore, and Sequel ORM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,19 @@ services:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
     profiles:
       - dev
+
+  postgres_db:
+    image: postgres:15
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+      - ./sift_backend/db/init:/docker-entrypoint-initdb.d
+    environment:
+      - POSTGRES_USER=app_user
+      - POSTGRES_PASSWORD=app_password
+      - POSTGRES_DB=app_db
+    restart: unless-stopped
+
+volumes:
+  pg_data:

--- a/sift_backend/Gemfile
+++ b/sift_backend/Gemfile
@@ -4,6 +4,8 @@ gem 'sinatra', '~> 3.0' # Or specify a more recent version if desired
 gem 'puma', '~> 6.0'    # Or specify a more recent version if desired
 gem 'json', '~> 2.6'
 gem 'rake', '~> 13.0'
+gem 'sequel', '~> 5.7' # Or a more recent version
+gem 'pg', '~> 1.5'     # Or a more recent version
 gem 'dotenv', '~> 2.8', groups: [:development, :test]
 
 group :development, :test do

--- a/sift_backend/Rakefile
+++ b/sift_backend/Rakefile
@@ -1,0 +1,111 @@
+# sift_backend/Rakefile
+require 'sequel'
+require 'dotenv/load' # Load .env variables for Rake tasks, if any are needed for DB connection
+require_relative 'config/database' # Load database connection
+
+# Ensure the migration extension is loaded
+Sequel.extension :migration
+
+namespace :db do
+  desc "Run database migrations"
+  task :migrate, [:version] do |t, args|
+    migrations_dir = File.join(__dir__, 'db', 'migrations')
+    target_version = args[:version] ? args[:version].to_i : nil
+
+    if !Dir.exist?(migrations_dir)
+      puts "Migrations directory not found: #{migrations_dir}"
+      next
+    end
+
+    puts "Running migrations..."
+    if target_version
+      puts "Migrating to version #{target_version}"
+      Sequel::Migrator.run(DB, migrations_dir, target: target_version)
+    else
+      puts "Migrating to latest"
+      Sequel::Migrator.run(DB, migrations_dir)
+    end
+    puts "Migrations complete."
+
+    # Automatically update schema.rb after migration (optional but good practice)
+    # Rake::Task['db:schema:dump'].invoke if Rake::Task.task_defined?('db:schema:dump')
+  end
+
+  desc "Rollback database migrations"
+  task :rollback, [:steps] do |t, args|
+    migrations_dir = File.join(__dir__, 'db', 'migrations')
+    steps = args[:steps] ? args[:steps].to_i : 1 # Default to 1 step back
+
+    if !Dir.exist?(migrations_dir)
+      puts "Migrations directory not found: #{migrations_dir}"
+      next
+    end
+
+    puts "Rolling back #{steps} migration(s)..."
+    current_version = Sequel::Migrator.get_current_migration_version(DB)
+    target_version = current_version - steps
+
+    if target_version < 0
+        # If rolling back further than the first migration, it migrates down to nothing (version 0)
+        puts "Target version is less than 0. This will revert all migrations."
+        Sequel::Migrator.run(DB, migrations_dir, target: 0)
+    else
+        Sequel::Migrator.run(DB, migrations_dir, target: target_version)
+    end
+    puts "Rollback complete. Current version is now: #{Sequel::Migrator.get_current_migration_version(DB)}"
+  end
+
+  desc "Check migration status"
+  task :status do
+    migrations_dir = File.join(__dir__, 'db', 'migrations')
+
+    if !Dir.exist?(migrations_dir)
+      puts "Migrations directory not found: #{migrations_dir}"
+      next
+    end
+
+    migrator = Sequel::TimestampMigrator.new(DB, migrations_dir, {}) # or IntegerMigrator if using integers
+
+    puts "Migration Status:"
+    puts "-----------------"
+    if migrator.is_current?
+      puts "Database is up to date."
+    else
+      puts "Database is NOT up to date."
+      # You could add more detailed status here, e.g., pending migrations.
+      # This requires more complex logic to list files and compare with schema_migrations table.
+    end
+    puts "Current Schema Version: #{DB[:schema_migrations].max(:filename) || 'None'}"
+
+    # A more detailed status showing each migration file and if it's applied:
+    # files = Dir["#{migrations_dir}/*.rb"].map { |f| File.basename(f, '.rb') }.sort
+    # applied_migrations = DB[:schema_migrations].select_map(:filename).to_set
+    # files.each do |f_name|
+    #   status = applied_migrations.include?(f_name) ? "Applied" : "Pending"
+    #   puts "#{f_name}: #{status}"
+    # end
+  end
+
+  # Optional: Task to create a new migration file with a timestamp
+  # desc "Create a new migration file: NAME=my_migration_name"
+  # task :create_migration do
+  #   name = ENV['NAME']
+  #   raise "Please specify migration name, e.g., NAME=create_users" unless name && !name.empty?
+  #   migrations_dir = File.join(__dir__, 'db', 'migrations')
+  #   Sequel::Migrator.create_migration_file(migrations_dir, name, :timestamp) # or :integer for sequential numbers
+  #   puts "Created migration file for '#{name}' in #{migrations_dir}"
+  # end
+
+  # Optional: Task to dump schema to a file (e.g., db/schema.rb)
+  # desc "Dump the database schema to db/schema.rb"
+  # task :schema_dump do
+  #   require 'sequel/extensions/schema_dumper'
+  #   schema = DB.dump_schema_migration(foreign_keys: false) # Or true, depending on preference
+  #   schema_file = File.join(__dir__, 'db', 'schema.rb')
+  #   File.write(schema_file, schema)
+  #   puts "Database schema dumped to #{schema_file}"
+  # end
+end
+
+# Default task
+task default: ['db:migrate']

--- a/sift_backend/app.rb
+++ b/sift_backend/app.rb
@@ -1,6 +1,7 @@
 require 'sinatra'
 require 'json'
 require 'dotenv/load' # Loads environment variables from .env
+require_relative 'config/database' # Load database configuration
 
 # In a more complex application, you would require route files here:
 # Dir[File.join(__dir__, 'app', 'routes', '*.rb')].each { |file| require file }

--- a/sift_backend/config/database.rb
+++ b/sift_backend/config/database.rb
@@ -1,0 +1,42 @@
+# sift_backend/config/database.rb
+require 'sequel'
+require 'logger' # Optional: for logging SQL queries
+
+# Define database connection parameters
+# Uses environment variables, falling back to defaults for Dockerized local development
+db_host = ENV.fetch('DB_HOST', 'localhost') # Use 'postgres_db' if your app service links to it by that name
+db_port = ENV.fetch('DB_PORT', '5432')
+db_name = ENV.fetch('DB_NAME', 'app_db')
+db_user = ENV.fetch('DB_USER', 'app_user')
+db_password = ENV.fetch('DB_PASSWORD', 'app_password')
+
+# Construct the database URL
+DATABASE_URL = ENV.fetch('DATABASE_URL', "postgres://#{db_user}:#{db_password}@#{db_host}:#{db_port}/#{db_name}")
+
+# Establish the database connection
+# The global constant DB is a common practice in Sequel apps
+DB = Sequel.connect(DATABASE_URL)
+
+# Optional: Log SQL queries to STDOUT (useful for development)
+# DB.loggers << Logger.new($stdout)
+
+# Load Sequel extensions for PostgreSQL specific types
+# These are good to have for enhanced functionality with JSON and HStore
+DB.extension :pg_json
+DB.extension :pg_hstore
+# For pgvector, direct type registration with Sequel might be complex or require a plugin.
+# Operations involving the 'vector' type are often done using raw SQL (DB.run, DB.fetch)
+# or specific methods provided by pgvector-ruby gem if you were to use it (not requested here).
+# For now, we ensure the extension is created at the DB level.
+
+# Verify connection (optional, but good for immediate feedback)
+begin
+  DB.test_connection
+  puts "Successfully connected to database: #{db_name} on #{db_host}:#{db_port}"
+rescue Sequel::DatabaseConnectionError => e
+  warn "Failed to connect to database: #{e.message}"
+  # Depending on the application, you might want to exit or handle this differently
+end
+
+# You might want to load your models here if you have them in separate files, e.g.:
+# Dir[File.join(__dir__, '..', 'models', '*.rb')].each { |file| require file }

--- a/sift_backend/db/init/init.sql
+++ b/sift_backend/db/init/init.sql
@@ -1,0 +1,12 @@
+-- init.sql
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS hstore;
+
+-- You can add other database initialization commands here if needed.
+-- For example, creating specific roles or other extensions.
+
+-- Print a message to the PostgreSQL logs to confirm execution (optional)
+DO $$
+BEGIN
+  RAISE NOTICE 'Database initialized with pgvector and hstore extensions.';
+END $$;

--- a/sift_backend/db/migrations/001_initial_setup.rb
+++ b/sift_backend/db/migrations/001_initial_setup.rb
@@ -1,0 +1,40 @@
+# sift_backend/db/migrations/001_initial_setup.rb
+Sequel.migration do
+  up do
+    puts "Running 001_initial_setup.rb: Up"
+    puts "This migration confirms the migration system is working."
+    puts "It also serves as a point to verify pgvector and hstore extensions."
+
+    # Optional: You can directly check for extensions if you want the migration to fail if they're not there.
+    # However, the init.sql script should handle their creation.
+    # This is more for confirmation during migration.
+    begin
+      db = self # In Sequel.migration blocks, self is the database connection
+      vector_exists = db.fetch("SELECT 1 FROM pg_extension WHERE extname = 'vector'").first
+      hstore_exists = db.fetch("SELECT 1 FROM pg_extension WHERE extname = 'hstore'").first
+
+      if vector_exists
+        puts "pgvector extension is enabled."
+      else
+        puts "WARNING: pgvector extension does NOT seem to be enabled."
+      end
+
+      if hstore_exists
+        puts "hstore extension is enabled."
+      else
+        puts "WARNING: hstore extension does NOT seem to be enabled."
+      end
+    rescue StandardError => e
+      puts "Could not query pg_extension table: #{e.message}"
+      puts "This might happen if the table doesn't exist yet or due to permissions."
+    end
+
+    # Sequel automatically creates its schema_migrations table on the first run
+    # if it doesn't exist. No need to create it manually.
+  end
+
+  down do
+    puts "Running 001_initial_setup.rb: Down"
+    puts "Reverting initial setup migration. No structural changes were made by this specific migration."
+  end
+end


### PR DESCRIPTION
This commit introduces a complete setup for a Sinatra backend application to use PostgreSQL with pgvector and hstore extensions, managed via Docker Compose, and interacted with using the Sequel ORM.

Key changes include:

1.  **Gemfile**: Added `sequel` and `pg` gems.
2.  **Docker Compose (`docker-compose.yml`)**:
    *   Added a `postgres_db` service using `postgres:15`.
    *   Configured persistent data volume (`pg_data`).
    *   Set up environment variables for database credentials.
    *   Included an initialization mechanism using `/docker-entrypoint-initdb.d`
        to run custom SQL scripts on startup.
3.  **Initialization Script (`sift_backend/db/init/init.sql`)**:
    *   Ensures `CREATE EXTENSION IF NOT EXISTS vector;` and
        `CREATE EXTENSION IF NOT EXISTS hstore;` are executed.
4.  **Sequel Configuration (`sift_backend/config/database.rb`)**:
    *   Establishes database connection using environment variables with
        fallbacks for local Docker development.
    *   Stores the connection in a global `DB` constant.
    *   Enables Sequel's `pg_json` and `pg_hstore` extensions.
5.  **Rake Tasks (`sift_backend/Rakefile`)**:
    *   Configured Rake tasks for Sequel migrations (`db:migrate`,
        `db:rollback`, `db:status`).
6.  **Initial Migration (`sift_backend/db/migrations/001_initial_setup.rb`)**:
    *   A simple migration to confirm the system works and to verify
        that the pgvector and hstore extensions are enabled in the database.
7.  **Application Update (`sift_backend/app.rb`)**:
    *   The main Sinatra application file now requires `config/database.rb`
        to ensure the database connection is available.

This setup provides a robust foundation for developing applications requiring vector similarity search and key-value storage capabilities within PostgreSQL, using Sequel for database interactions and migrations.