### PR TITLE
Configure CORS for Sinatra backend

### DIFF
--- a/sift_backend/Gemfile
+++ b/sift_backend/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'sinatra', '~> 3.0' # Or specify a more recent version if desired
 gem 'puma', '~> 6.0'    # Or specify a more recent version if desired
 gem 'json', '~> 2.6'
+gem 'sinatra-cross_origin'
 gem 'rake', '~> 13.0'
 gem 'sequel', '~> 5.7' # Or a more recent version
 gem 'pg', '~> 1.5'     # Or a more recent version
@@ -10,5 +11,5 @@ gem 'dotenv', '~> 2.8', groups: [:development, :test]
 
 group :development, :test do
   gem 'rubocop', '~> 1.50', require: false # Or specify a more recent version
-  gem 'rubocop-sinatra', '~> 1.4', require: false # Or specify a more recent version
+  # gem 'rubocop-sinatra', '~> 1.4', require: false # Or specify a more recent version
 end

--- a/sift_backend/Gemfile.lock
+++ b/sift_backend/Gemfile.lock
@@ -1,0 +1,74 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
+    dotenv (2.8.1)
+    json (2.12.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.7.4)
+    parallel (1.27.0)
+    parser (3.3.8.0)
+      ast (~> 2.4.1)
+      racc
+    pg (1.5.9)
+    prism (1.4.0)
+    puma (6.6.0)
+      nio4r (~> 2.0)
+    racc (1.8.1)
+    rack (2.2.17)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    rainbow (3.1.1)
+    rake (13.3.0)
+    regexp_parser (2.10.0)
+    rubocop (1.76.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.45.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.45.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    sequel (5.93.0)
+      bigdecimal
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
+      tilt (~> 2.0)
+    sinatra-cross_origin (0.4.0)
+    tilt (2.6.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+
+PLATFORMS
+  x86_64-linux-gnu
+
+DEPENDENCIES
+  dotenv (~> 2.8)
+  json (~> 2.6)
+  pg (~> 1.5)
+  puma (~> 6.0)
+  rake (~> 13.0)
+  rubocop (~> 1.50)
+  sequel (~> 5.7)
+  sinatra (~> 3.0)
+  sinatra-cross_origin
+
+BUNDLED WITH
+   2.4.20

--- a/sift_backend/app.rb
+++ b/sift_backend/app.rb
@@ -1,7 +1,43 @@
 require 'sinatra'
 require 'json'
+require 'sinatra/cross_origin'
 require 'dotenv/load' # Loads environment variables from .env
 require_relative 'config/database' # Load database configuration
+
+configure do
+  enable :cross_origin
+end
+
+# CORS Configuration
+# For development, allow requests from the frontend development server.
+# In production, this should be set to the actual frontend domain.
+set :allow_origin, ENV.fetch('FRONTEND_URL', 'http://localhost:5173')
+set :allow_methods, [:get, :post, :put, :delete, :options]
+set :allow_headers, ['Content-Type', 'Authorization', 'X-Requested-With']
+set :expose_headers, ['Content-Type'] # Optional: Add any other headers you want to expose
+
+# Support for preflight requests
+# The OPTIONS method is used by browsers to send a "preflight" request to the server
+# to determine if the actual request (e.g., a POST with a JSON body) is safe to send.
+# This is a crucial part of the CORS mechanism.
+options '*' do
+  response.headers['Allow'] = 'GET, POST, PUT, DELETE, OPTIONS'
+  response.headers['Access-Control-Allow-Origin'] = settings.allow_origin
+  response.headers['Access-Control-Allow-Headers'] = settings.allow_headers.join(', ')
+  response.headers['Access-Control-Allow-Methods'] = settings.allow_methods.map(&:to_s).map(&:upcase).join(', ')
+  200 # HTTP 200 OK
+end
+
+#
+# Security Note on CORS Configuration:
+# It is crucial to be very careful with CORS settings in a production environment.
+# - Avoid using `*` (wildcard) for `Access-Control-Allow-Origin` if your application handles sensitive data or credentials.
+#   Allowing any origin to make requests can expose your application to cross-site request forgery (CSRF) like attacks
+#   if combined with `Access-Control-Allow-Credentials: true`.
+# - Always specify the exact, trusted domains that should be allowed to access your API.
+#   For example: `set :allow_origin, 'https://your-trusted-frontend.com'`
+#   Or manage a list of allowed origins dynamically based on your application's needs.
+#
 
 # In a more complex application, you would require route files here:
 # Dir[File.join(__dir__, 'app', 'routes', '*.rb')].each { |file| require file }
@@ -33,6 +69,24 @@ end
 # get '/' do
 #   'Hello SIFT Toolbox API!'
 # end
+
+#
+# Manual CORS Configuration (Alternative to using sinatra-cross_origin gem)
+#
+# before do
+#   headers['Access-Control-Allow-Origin'] = ENV.fetch('FRONTEND_URL', 'http://localhost:5173')
+#   headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS'
+#   headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization, X-Requested-With'
+# end
+#
+# options '*' do
+#   response.headers['Allow'] = 'GET, POST, PUT, DELETE, OPTIONS'
+#   response.headers['Access-Control-Allow-Origin'] = ENV.fetch('FRONTEND_URL', 'http://localhost:5173')
+#   response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization, X-Requested-With'
+#   response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS'
+#   halt 200
+# end
+#
 
 # If you prefer a modular (classic) style Sinatra app:
 # class App < Sinatra::Base


### PR DESCRIPTION
This commit introduces CORS (Cross-Origin Resource Sharing) configuration to the Sinatra application to allow requests from a frontend application running on a different origin.

Key changes:
- Added the `sinatra-cross_origin` gem to handle CORS.
- Configured `app.rb` to:
    - Allow origins specified by the `FRONTEND_URL` environment variable, defaulting to `http://localhost:5173`.
    - Allow common HTTP methods (GET, POST, PUT, DELETE, OPTIONS).
    - Allow common headers (Content-Type, Authorization, X-Requested-With).
    - Handle preflight OPTIONS requests.
- Included a commented-out alternative for manual CORS configuration without the gem.
- Added a security note regarding the importance of not using wildcard origins in production.

The `rubocop-sinatra` gem was temporarily commented out in the Gemfile due to installation issues in the environment, which can be addressed separately.