### PR TITLE
feat: Implement basic logging framework for Sinatra backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 sift-toolbox.json
 *.env
+sift_backend/log/*.log

--- a/sift_backend/README.md
+++ b/sift_backend/README.md
@@ -70,3 +70,51 @@ You can test the basic health check endpoint by navigating to `http://localhost:
 *   `Gemfile.lock`: Records the exact versions of installed gems.
 *   `README.md`: This file.
 *   `.env`: (Optional, create manually) For environment variables.
+
+## Logging
+
+**Configuration**:
+
+The logger is initialized in `sift_backend/app.rb` within the `configure` block. The behavior of the logger is determined by the `RACK_ENV` environment variable:
+
+*   **Development** (if `RACK_ENV` is `development` or not set):
+    *   Logs are sent to `STDOUT` (your console).
+    *   The log level is set to `DEBUG`, which is verbose and useful for development.
+*   **Production** (if `RACK_ENV` is `production`):
+    *   Logs are written to the file `sift_backend/log/production.log`.
+    *   The log level is set to `INFO`, capturing important events but less verbose than debug.
+
+The `RACK_ENV` variable can be set in your `.env` file or directly in your shell environment before starting the server.
+
+**Usage in Routes**:
+
+You can access the logger instance within your Sinatra routes using `settings.logger`.
+
+Example:
+```ruby
+# Inside a Sinatra route
+get '/some_route' do
+  settings.logger.debug "This is a debug message for: #{request.path_info}"
+  settings.logger.info "Informational message from /some_route"
+  settings.logger.warn "A warning occurred in /some_route"
+  settings.logger.error "An error was encountered in /some_route"
+  # ...
+  "Route completed"
+end
+```
+
+**Log Levels**:
+
+The logger supports several levels to categorize the severity and importance of messages:
+
+*   `DEBUG`: Detailed information, typically of interest only when diagnosing problems.
+*   `INFO`: Confirmation that things are working as expected.
+*   `WARN`: An indication that something unexpected happened, or indicative of some problem in the near future (e.g., ‘disk space low’). The software is still working as expected.
+*   `ERROR`: Due to a more serious problem, the software has not been able to perform some function.
+*   `FATAL`: A severe error, indicating that the application will likely terminate.
+
+**Log Rotation (Production)**:
+
+When logging to files in a production environment (like `log/production.log`), it's crucial to manage log file sizes to prevent them from consuming excessive disk space. Log rotation is the process of archiving old log files and starting new ones.
+
+This is typically an operational concern handled by system utilities like `logrotate` on Linux or other platform-specific logging services. It is not directly managed by the application code but should be configured as part of the server deployment process.


### PR DESCRIPTION
This commit introduces a logging setup for the Sinatra application in `sift_backend/`.

Key changes:
- Integrated Ruby's built-in `Logger` class.
- Logger configuration in `sift_backend/app.rb`:
    - Logs to `STDOUT` with `DEBUG` level in development (`RACK_ENV` != 'production').
    - Logs to `sift_backend/log/production.log` with `INFO` level in production (`RACK_ENV` = 'production').
    - The logger instance is available via `settings.logger`.
- Added example logging in the `/api/health` route and a new `/api/test_log` route.
- Created `sift_backend/log` directory with a `.keep` file for git tracking.
- Added `sift_backend/log/*.log` to `.gitignore`.
- Updated `sift_backend/README.md` with documentation for the logging setup, including configuration, usage, log levels, and a note on log rotation for production.
- Included a comment in `sift_backend/app.rb` explaining the concept of log rotation.

This setup provides a foundation for debugging and monitoring requests within the application.