### PR TITLE
feat: Define initial database schema and migration

### DIFF
--- a/sift_backend/db/migrations/20250605230748_create_core_tables.rb
+++ b/sift_backend/db/migrations/20250605230748_create_core_tables.rb
@@ -1,0 +1,54 @@
+Sequel.migration do
+  up do
+    # Enable uuid-ossp extension if not already enabled by init.sql, for gen_random_uuid()
+    # DB.run('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";') # Prefer init.sql for this
+
+    DB.run %{
+      CREATE TABLE sift_analyses (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_query_text TEXT,
+        user_image_filename VARCHAR(255),
+        report_type VARCHAR(100),
+        model_id_used VARCHAR(255),
+        generated_report_text TEXT,
+        created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    }
+
+    DB.run %{
+      CREATE TABLE chat_messages (
+        id SERIAL PRIMARY KEY,
+        sift_analysis_id UUID NOT NULL REFERENCES sift_analyses(id) ON DELETE CASCADE,
+        sender_type VARCHAR(50) NOT NULL,
+        message_text TEXT NOT NULL,
+        model_id_used VARCHAR(255),
+        "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        grounding_sources_json JSONB
+      );
+    }
+
+    DB.run %{
+      CREATE TABLE processed_urls (
+        id SERIAL PRIMARY KEY,
+        url_hash VARCHAR(64) UNIQUE NOT NULL, -- SHA256 produces 64 hex characters
+        original_url TEXT NOT NULL,
+        extracted_title TEXT,
+        extracted_content TEXT,
+        content_embedding vector(1536), -- pgvector type
+        processed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        last_fetched_at TIMESTAMP WITH TIME ZONE
+      );
+    }
+  end
+
+  down do
+    DB.run %{ DROP TABLE IF EXISTS processed_urls; }
+    DB.run %{ DROP TABLE IF EXISTS chat_messages; }
+    DB.run %{ DROP TABLE IF EXISTS sift_analyses; }
+    # If you had enabled any extensions like "uuid-ossp" specifically in the up method
+    # and not in init.sql, you might consider dropping them here,
+    # but typically extensions are managed at a database level, not per-migration.
+    # DB.run('DROP EXTENSION IF EXISTS "uuid-ossp";')
+  end
+end


### PR DESCRIPTION
This commit introduces the initial database schema for the SIFT Toolbox backend. It includes a new Sequel migration file that creates the following tables:

- `sift_analyses`: Stores each initial SIFT analysis report.
- `chat_messages`: Stores individual messages within a SIFT analysis chat session, linked to `sift_analyses`.
- `processed_urls`: Stores information about URLs that have been fetched and processed, including their content embeddings using the pgvector `vector` type.

The migration includes `up` methods to create these tables with appropriate columns, data types, primary keys, foreign keys, and constraints. It also includes corresponding `down` methods to drop these tables.

The `sift_analyses` table uses UUIDs for its primary key. The `processed_urls` table is prepared for pgvector by using the `vector(1536)` data type for embeddings. The `init.sql` script is expected to handle the creation of the `pgvector` extension itself.