### PR TITLE
Add POST /api/sift/initiate endpoint for SIFT analysis requests

### DIFF
--- a/sift_backend/services/sift_service.rb
+++ b/sift_backend/services/sift_service.rb
@@ -1,0 +1,64 @@
+# sift_backend/services/sift_service.rb
+require 'json'
+
+class SiftService
+  def self.initiate_analysis(text: nil, image_file: nil, report_type:, selected_model_id:, model_config_params:)
+    # Conceptual: In a real scenario, this service would interact with an AI model.
+    # For now, it will simulate yielding data chunks for SSE.
+
+    # Simulate some processing and yield data
+    yield "event: message
+data: #{ { status: 'Processing started for report type: ' + report_type }.to_json }
+
+"
+    sleep 0.5 # Simulate work
+
+    if image_file
+      # In a real app, you'd process the image_file (e.g., save it, send to AI)
+      # image_file is a hash like: {:filename=>"...", :type=>"...", :name=>"...", :tempfile=>#<Tempfile:...>, :head=>"..."}
+      yield "event: message
+data: #{ { status: 'Processing image: ' + image_file[:filename].to_s }.to_json }
+
+"
+      sleep 0.5 # Simulate work
+    end
+
+    if text
+      yield "event: message
+data: #{ { status: 'Processing text: ' + text[0..30] + "..." }.to_json }
+
+"
+      sleep 0.5 # Simulate work
+    end
+
+    yield "event: message
+data: #{ { status: 'Using model: ' + selected_model_id }.to_json }
+
+"
+    sleep 0.5
+
+    # Simulate streaming of analysis results
+    5.times do |i|
+      yield "event: data_chunk
+data: #{ { chunk: i + 1, content: "This is chunk number #{i + 1} of the analysis." }.to_json }
+
+"
+      sleep 0.3 # Simulate delay between chunks
+    end
+
+    yield "event: analysis_complete
+data: #{ { status: 'Analysis finished.', report_summary: 'A full report would be generated here.' }.to_json }
+
+"
+  rescue StandardError => e
+    # In case of an error within the service, yield an error event
+    error_message = "Error during SIFT analysis: #{e.message}"
+    puts "Error in SiftService: #{error_message}" # Log to server console
+    puts e.backtrace.join("
+")
+    yield "event: error
+data: #{ { message: error_message, details: e.class.name }.to_json }
+
+"
+  end
+end


### PR DESCRIPTION
This commit introduces a new Sinatra endpoint `POST /api/sift/initiate` to handle the initial SIFT (Stop, Investigate, Find, Trace) analysis requests from you.

Key features of this endpoint:
- Handles `POST` requests with `multipart/form-data`.
- Parses the following parameters:
    - `userInputText` (String, optional)
    - `userImageFile` (File, optional)
    - `reportType` (String, required)
    - `selectedModelId` (String, required)
    - `modelConfigParams` (JSON String, optional)
- Validates the presence of required parameters and that either text or an image is provided. Returns a 400 error with a JSON message for invalid requests.
- Parses `modelConfigParams` from a JSON string into a Ruby hash.
- Sets up and manages a Server-Sent Events (SSE) stream (`text/event-stream`) back to you.
- Calls a new (conceptual) `SiftService.initiate_analysis` method, passing the parsed parameters. This service is responsible for the actual analysis logic and yielding data chunks.
- Streams data chunks received from `SiftService` to you via SSE.
- Includes error handling for issues during the streaming process or from the service, sending an `event: error` to you.

A placeholder `SiftService` has been created in `sift_backend/services/sift_service.rb` to simulate the analysis process and data streaming for demonstration and testing purposes. No additional gems for multipart parsing were required, as Sinatra's built-in capabilities are sufficient.