### PR TITLE
feat: Implement AIService for ruby_llm integration

### DIFF
--- a/sift_backend/Gemfile
+++ b/sift_backend/Gemfile
@@ -8,6 +8,7 @@ gem 'rake', '~> 13.0'
 gem 'sequel', '~> 5.7' # Or a more recent version
 gem 'pg', '~> 1.5'     # Or a more recent version
 gem 'dotenv', '~> 2.8', groups: [:development, :test]
+gem 'ruby_llm'
 
 group :development, :test do
   gem 'rubocop', '~> 1.50', require: false # Or specify a more recent version

--- a/sift_backend/config/initializers/ruby_llm.rb
+++ b/sift_backend/config/initializers/ruby_llm.rb
@@ -1,0 +1,7 @@
+# config/initializers/ruby_llm.rb
+RubyLLM.configure do |config|
+  config.gemini_api_key = ENV.fetch('GEMINI_API_KEY', nil)
+  config.openai_api_key = ENV.fetch('OPENAI_API_KEY', nil)
+  config.openrouter_api_key = ENV.fetch('OPENROUTER_API_KEY', nil)
+  # config.openai_api_base = 'https://openrouter.ai/api/v1' # Example for OpenRouter if not using its specific key config
+end

--- a/sift_backend/lib/image_handler.rb
+++ b/sift_backend/lib/image_handler.rb
@@ -1,0 +1,33 @@
+# sift_backend/lib/image_handler.rb
+
+module ImageHandler
+  # Simulates processing an uploaded image file.
+  # In a real application, this would handle Tempfiles, save them,
+  # or convert to Base64 if needed by the LLM service.
+  # For ruby_llm, a file path is often sufficient.
+  #
+  # @param image_file_details [Hash] Expected to contain info like
+  #   `{ path: "/path/to/temp_image.jpg", mime_type: "image/jpeg" }` or
+  #   `{ base64_data: "...", mime_type: "image/jpeg" }`.
+  # @return [Hash, nil] A hash with image path if processing is successful,
+  #   e.g., `{ path: "processed_image.jpg" }`, or nil if no image_file_details.
+  def self.process_image(image_file_details)
+    return nil if image_file_details.nil? || image_file_details.empty?
+
+    # For now, we'll assume if a path is given, it's usable.
+    # If base64_data is given, we'd ideally save it to a temp file
+    # and return that path. This placeholder will just return the path if present.
+    if image_file_details[:path]
+      puts "ImageHandler: Using provided path: #{image_file_details[:path]}"
+      return { path: image_file_details[:path] }
+    elsif image_file_details[:base64_data]
+      # In a real scenario, save the base64 data to a temporary file
+      # and return its path.
+      temp_path = "temp_image_from_base64.#{image_file_details[:mime_type].split('/').last || 'jpg'}"
+      puts "ImageHandler: Simulating saving Base64 data to #{temp_path}"
+      # File.write(temp_path, Base64.decode64(image_file_details[:base64_data])) # Example
+      return { path: temp_path } # Return a simulated path
+    end
+    nil # Should not happen if image_file_details is valid
+  end
+end

--- a/sift_backend/lib/prompts.rb
+++ b/sift_backend/lib/prompts.rb
@@ -1,0 +1,30 @@
+# sift_backend/lib/prompts.rb
+
+module Prompts
+  PROMPT_TEMPLATES = {
+    sift_chat_system_prompt: "You are a helpful assistant for the SIFT application. Be concise and helpful.",
+    sift_full_check_prompt: "Perform a full check on the following input: %{user_input}",
+    # Add other report types here as needed
+    # e.g., sift_summary_prompt: "Summarize this: %{user_input}"
+  }.freeze
+
+  # Fetches a prompt template and interpolates values if provided.
+  #
+  # @param prompt_key [Symbol] The key for the prompt template (e.g., :sift_full_check_prompt).
+  # @param values [Hash] A hash of values to interpolate into the prompt string.
+  # @return [String] The processed prompt string.
+  def self.get_prompt(prompt_key, values = {})
+    template = PROMPT_TEMPLATES[prompt_key]
+    return "Prompt not found for key: #{prompt_key}" unless template
+
+    if values.any?
+      template % values
+    else
+      template
+    end
+  end
+end
+
+# Example Usage:
+# puts Prompts.get_prompt(:sift_chat_system_prompt)
+# puts Prompts.get_prompt(:sift_full_check_prompt, user_input: "some text here")

--- a/sift_backend/services/ai_service.rb
+++ b/sift_backend/services/ai_service.rb
@@ -1,0 +1,186 @@
+# sift_backend/services/ai_service.rb
+
+require 'json'
+require 'ruby_llm' # Assuming ruby_llm is loaded via Bundler or accessible
+require_relative '../lib/prompts' # Adjust path if necessary
+require_relative '../lib/image_handler' # Adjust path if necessary
+
+module AIService
+  class << self
+    # Unified streaming method to generate responses from an AI model via ruby_llm.
+    #
+    # @param chat_session_id [String, nil] Optional, for logging or future use.
+    # @param user_input_text [String, nil] The user's text query.
+    # @param image_file_details [Hash, nil] Processed image data (e.g., { path: "/path/to/image.jpg" }).
+    # @param report_type [String] Type of report/prompt to use (e.g., "FULL_CHECK").
+    # @param selected_model_id [String] The ID of the model to use (e.g., "gemini-1.5-pro-latest").
+    # @param model_config_params [Hash] Configuration for the model (e.g., { temperature: 0.7 }).
+    # @param chat_history [Array<Hash>] Array of previous messages [{role: :user, content: "..."}, ...].
+    # @param block [Proc] Block to yield SSE formatted chunks to.
+    # @return [RubyLLM::Message, nil] The final AI message object for persistence, or nil if setup fails.
+    def generate_sift_stream(
+      chat_session_id: nil,
+      user_input_text: nil,
+      image_file_details: nil,
+      report_type:,
+      selected_model_id:,
+      model_config_params: {},
+      chat_history: [],
+      &block
+    )
+      unless block_given?
+        puts "AIService: Error - No block provided for streaming."
+        # Or raise ArgumentError, "A block is required for streaming."
+        return nil
+      end
+
+      puts "AIService: Generating SIFT stream with model #{selected_model_id}"
+      puts "AIService: Report Type: #{report_type}, Session ID: #{chat_session_id || 'N/A'}"
+      puts "AIService: Model Config: #{model_config_params}"
+
+      begin
+        chat = RubyLLM.chat(model: selected_model_id)
+
+        # 1. Apply model configurations
+        if model_config_params[:temperature]
+          chat.with_temperature(model_config_params[:temperature].to_f)
+        end
+        # Add other common params like max_tokens, top_p, etc. as needed
+        # chat.with_max_tokens(model_config_params[:max_tokens]) if model_config_params[:max_tokens]
+
+        # 2. Set system instructions (applies to the whole conversation)
+        # This should ideally be set once if the chat object is long-lived.
+        # For stateless calls, set it every time.
+        system_prompt = Prompts.get_prompt(:sift_chat_system_prompt)
+        chat.with_instructions(system_prompt)
+
+        # 3. Load chat history if provided
+        if chat_history && !chat_history.empty?
+          puts "AIService: Loading chat history (#{chat_history.length} messages)"
+          chat_history.each do |msg|
+            # Ensure role is a symbol as ruby_llm might expect
+            chat.messages.build(role: msg[:role].to_sym, content: msg[:content])
+          end
+        end
+
+        # 4. Prepare image if present
+        image_path = nil
+        if image_file_details
+          processed_image = ImageHandler.process_image(image_file_details)
+          image_path = processed_image[:path] if processed_image && processed_image[:path]
+          puts "AIService: Processed image, path: #{image_path}" if image_path
+        end
+
+        # 5. Construct the current user prompt
+        current_user_prompt_text = ""
+        if chat_history && !chat_history.empty?
+          # If there's history, the new user_input_text is the current prompt
+          current_user_prompt_text = user_input_text
+        else
+          # For an initial request, use the report_type to format the prompt
+          # The SIFT_FULL_CHECK_PROMPT might include a placeholder for the image description
+          # or we might need to append a standard "Image is attached" message.
+          # For now, we assume the prompt template handles user_input_text.
+          prompt_key = "sift_#{report_type.downcase}_prompt".to_sym
+          current_user_prompt_text = Prompts.get_prompt(prompt_key, user_input: user_input_text)
+        end
+
+        unless current_user_prompt_text && !current_user_prompt_text.strip.empty?
+          # Handle cases where prompt might be empty if user_input_text is nil and not handled by Prompts module
+          error_message = "AIService: Error - User input text is empty or could not form a valid prompt."
+          puts error_message
+          yield "event: error
+data: #{ {error: "Prompt generation failed", type: "PromptError"}.to_json }
+
+"
+          return nil
+        end
+
+        puts "AIService: Asking LLM with prompt: "#{current_user_prompt_text.lines.first.strip}...""
+        puts "AIService: With image: #{image_path || 'No'}"
+
+        # 6. Make the streaming call
+        final_message = chat.ask(current_user_prompt_text, with: image_path) do |chunk|
+          if chunk&.content&.is_a?(String)
+            # SSE format: data: { "delta": "chunk content" }
+
+
+            sse_data = { delta: chunk.content }.to_json
+            block.call("data: #{sse_data}
+
+")
+          elsif chunk&.tool_calls # Handle potential tool calls if the model supports/returns them
+            # You might want to serialize tool_calls if your frontend expects them
+            # puts "AIService: Received tool calls: #{chunk.tool_calls}"
+            # sse_data = { tool_calls: chunk.tool_calls }.to_json # Example
+            # block.call("data: #{sse_data}
+
+")
+          end
+        end
+
+        puts "AIService: Streaming complete. Final message role: #{final_message&.role}"
+        return final_message # Return the complete message object for persistence
+
+      rescue RubyLLM::Error => e
+        error_message = "AIService: RubyLLM Error - #{e.message}"
+        puts error_message
+        error_json = { error: e.message, type: e.class.name, details: e.try(:response)&.body }.to_json
+        block.call("event: error
+data: #{error_json}
+
+")
+        return nil # Indicate failure
+      rescue StandardError => e
+        error_message = "AIService: Standard Error - #{e.class.name}: #{e.message}
+Backtrace: #{e.backtrace.join("
+  ")}"
+        puts error_message
+        error_json = { error: e.message, type: e.class.name }.to_json
+        block.call("event: error
+data: #{error_json}
+
+")
+        return nil # Indicate failure
+      end
+    end
+  end
+end
+
+# Example (conceptual, not run directly here):
+#
+# if __FILE__ == $PROGRAM_NAME
+#   # This is just for testing the structure; won't run in a real app context like this.
+#   # Setup mock ruby_llm and ENV vars if you were to run this standalone.
+#   puts "Example AIService call (conceptual):"
+#
+#   # Mock ENV for initializer (if it were run)
+#   # ENV['GEMINI_API_KEY'] = 'fake_gemini_key'
+#
+#   # Mock configuration for ruby_llm if not using the initializer directly
+#   # RubyLLM.configure do |config|
+#   #   config.gemini_api_key = "fake_key"
+#   # end
+#
+#   # Example call
+#   AIService.generate_sift_stream(
+#     chat_session_id: "session123",
+#     user_input_text: "Tell me about cats.",
+#     # image_file_details: { path: "path/to/cat.jpg", mime_type: "image/jpeg" },
+#     report_type: "FULL_CHECK",
+#     selected_model_id: "gemini-1.5-pro-latest", # Or your preferred model
+#     model_config_params: { temperature: 0.7 },
+#     chat_history: [{role: :user, content: "What are common pets?"}, {role: :assistant, content: "Dogs and cats are common pets."}]
+#   ) do |chunk|
+#     print chunk # Expect SSE formatted output
+#   end
+#
+#   # Example with an image
+#   # AIService.generate_sift_stream(
+#   #   user_input_text: "What is in this image?",
+#   #   image_file_details: { path: "test_image.png", mime_type: "image/png" }, # Create a dummy test_image.png
+#   #   report_type: "IMAGE_ANALYSIS", # Assuming a prompt key like :sift_image_analysis_prompt
+#   #   selected_model_id: "gemini-1.5-pro-latest",
+#   #   &block
+#   # )
+# end


### PR DESCRIPTION
This commit introduces a new AIService class to interact with various AI providers using the ruby_llm gem.

Key changes include:
- Added `ruby_llm` to `sift_backend/Gemfile`.
- Created an initializer for `ruby_llm` at `sift_backend/config/initializers/ruby_llm.rb` to configure API keys.
- Implemented placeholder modules `ImageHandler` and `Prompts` in `sift_backend/lib/` to support the AIService.
- Created the `AIService` in `sift_backend/services/ai_service.rb` with a `generate_sift_stream` method.

The `generate_sift_stream` method provides a unified interface for:
- Selecting AI models.
- Configuring model parameters (e.g., temperature).
- Handling text and image inputs.
- Managing chat history for contextual conversations.
- Streaming responses in Server-Sent Events (SSE) format.
- Robust error handling for AI provider issues and other exceptions.
- Returning the final AI message for persistence.

This service is designed to be the primary interface for AI interactions within the SIFT backend, leveraging `ruby_llm` for multi-provider support.