### PR TITLE
feat: Implement robust image handling for ruby_llm

### DIFF
--- a/sift_backend/lib/image_handler.rb
+++ b/sift_backend/lib/image_handler.rb
@@ -1,33 +1,89 @@
 # sift_backend/lib/image_handler.rb
+require 'fileutils'
+require 'securerandom'
+require 'tempfile' # Ensure Tempfile class is explicitly available
 
 module ImageHandler
-  # Simulates processing an uploaded image file.
-  # In a real application, this would handle Tempfiles, save them,
-  # or convert to Base64 if needed by the LLM service.
-  # For ruby_llm, a file path is often sufficient.
+  # Processes an uploaded image file from Sinatra params.
   #
-  # @param image_file_details [Hash] Expected to contain info like
-  #   `{ path: "/path/to/temp_image.jpg", mime_type: "image/jpeg" }` or
-  #   `{ base64_data: "...", mime_type: "image/jpeg" }`.
-  # @return [Hash, nil] A hash with image path if processing is successful,
-  #   e.g., `{ path: "processed_image.jpg" }`, or nil if no image_file_details.
-  def self.process_image(image_file_details)
-    return nil if image_file_details.nil? || image_file_details.empty?
-
-    # For now, we'll assume if a path is given, it's usable.
-    # If base64_data is given, we'd ideally save it to a temp file
-    # and return that path. This placeholder will just return the path if present.
-    if image_file_details[:path]
-      puts "ImageHandler: Using provided path: #{image_file_details[:path]}"
-      return { path: image_file_details[:path] }
-    elsif image_file_details[:base64_data]
-      # In a real scenario, save the base64 data to a temporary file
-      # and return its path.
-      temp_path = "temp_image_from_base64.#{image_file_details[:mime_type].split('/').last || 'jpg'}"
-      puts "ImageHandler: Simulating saving Base64 data to #{temp_path}"
-      # File.write(temp_path, Base64.decode64(image_file_details[:base64_data])) # Example
-      return { path: temp_path } # Return a simulated path
+  # If a block is provided, it yields a hash containing the path to a
+  # securely copied temporary file and its original MIME type.
+  # This temporary file is automatically cleaned up after the block executes.
+  # The method then returns the value yielded by the block.
+  #
+  # If no block is provided, it returns the hash with the file path and MIME type.
+  # In this case, the CALLER IS RESPONSIBLE for deleting the file at `file_path`.
+  #
+  # Returns `nil` if the input is invalid, file processing fails, or
+  # (if a block is given and an error occurs outside the block's execution but before it returns)
+  # the block's own return value in other cases.
+  #
+  # @param sinatra_file_param [Hash] The Sinatra file upload hash.
+  #   Expected keys: `:tempfile` (a Tempfile object), `:type` (String), `:filename` (String).
+  # @yield [Hash] `{ file_path: String, original_mime_type: String }` if block is given.
+  # @return [Object, nil] The result of the block if a block is given,
+  #   or a Hash `{ file_path: String, original_mime_type: String }` if no block,
+  #   or `nil` on failure or invalid input.
+  def self.process_uploaded_image(sinatra_file_param)
+    # Input validation
+    unless sinatra_file_param.is_a?(Hash) &&
+           sinatra_file_param[:tempfile].is_a?(Tempfile) &&
+           sinatra_file_param[:type].is_a?(String) && !sinatra_file_param[:type].empty? &&
+           sinatra_file_param[:filename].is_a?(String) && !sinatra_file_param[:filename].empty?
+      # Consider logging this invalid input if a logger is available
+      # puts "ImageHandler: Invalid sinatra_file_param provided: #{sinatra_file_param.inspect}"
+      return nil
     end
-    nil # Should not happen if image_file_details is valid
+
+    tempfile = sinatra_file_param[:tempfile]
+    original_mime_type = sinatra_file_param[:type]
+    original_filename = sinatra_file_param[:filename]
+
+    # Construct path for the new temporary file
+    # Using File.extname(original_filename) is generally safer than tempfile.path for extension
+    new_persistent_path = File.join(
+      Dir.tmpdir,
+      "sift_image_#{SecureRandom.hex(8)}#{File.extname(original_filename)}"
+    )
+
+    begin
+      # Copy the uploaded tempfile to the new persistent path
+      FileUtils.copy_file(tempfile.path, new_persistent_path)
+
+      payload = { file_path: new_persistent_path, original_mime_type: original_mime_type }
+
+      if block_given?
+        block_result = nil
+        begin
+          # Yield the payload to the block and store its result
+          block_result = yield(payload)
+        ensure
+          # Always clean up the new_persistent_path if a block was executed,
+          # regardless of whether an error occurred within the block or not.
+          FileUtils.rm_f(new_persistent_path)
+        end
+        return block_result # Return what the block returned
+      else
+        # No block given: return the payload directly. Caller is responsible for cleanup.
+        return payload
+      end
+    rescue StandardError => e
+      # Log error if a logger was available
+      # puts "ImageHandler: Error processing file: #{e.class} - #{e.message}
+Backtrace: #{e.backtrace.join("
+  ")}"
+
+      # If the file was copied before an error occurred (e.g., error in yield),
+      # try to clean it up.
+      if new_persistent_path && File.exist?(new_persistent_path)
+          # If a block was not given, this file was intended for the caller to manage,
+          # but an error here means the caller won't get the path, so clean up.
+          # If a block was given, the inner ensure should have cleaned it.
+          # This acts as a fallback cleanup for the case where no block is given
+          # and an error happens after copy but before return.
+          FileUtils.rm_f(new_persistent_path) unless block_given?
+      end
+      return nil # Indicate failure by returning nil
+    end
   end
 end

--- a/sift_backend/services/ai_service.rb
+++ b/sift_backend/services/ai_service.rb
@@ -65,10 +65,12 @@ module AIService
 
         # 4. Prepare image if present
         image_path = nil
-        if image_file_details
-          processed_image = ImageHandler.process_image(image_file_details)
-          image_path = processed_image[:path] if processed_image && processed_image[:path]
-          puts "AIService: Processed image, path: #{image_path}" if image_path
+        if image_file_details && image_file_details[:file_path]
+          image_path = image_file_details[:file_path]
+          # We can keep the log line, or adjust it if :original_mime_type is also useful to log
+          puts "AIService: Using image file provided at path: #{image_path} (MIME: #{image_file_details[:original_mime_type]})"
+        else
+          puts "AIService: No image file details provided or path is missing."
         end
 
         # 5. Construct the current user prompt

--- a/sift_backend/services/sift_service.rb
+++ b/sift_backend/services/sift_service.rb
@@ -1,64 +1,74 @@
 # sift_backend/services/sift_service.rb
 require 'json'
+require_relative '../lib/image_handler' # For ImageHandler.process_uploaded_image
+require_relative './ai_service'     # For AIService.generate_sift_stream
 
-class SiftService
-  def self.initiate_analysis(text: nil, image_file: nil, report_type:, selected_model_id:, model_config_params:)
-    # Conceptual: In a real scenario, this service would interact with an AI model.
-    # For now, it will simulate yielding data chunks for SSE.
+# It's good practice to have a logger available in services
+# For now, we'll use puts for simplicity if no logger is passed or configured.
+# require 'logger'
+# LOGGER = Logger.new(STDOUT) # Example
 
-    # Simulate some processing and yield data
-    yield "event: message
-data: #{ { status: 'Processing started for report type: ' + report_type }.to_json }
-
-"
-    sleep 0.5 # Simulate work
-
-    if image_file
-      # In a real app, you'd process the image_file (e.g., save it, send to AI)
-      # image_file is a hash like: {:filename=>"...", :type=>"...", :name=>"...", :tempfile=>#<Tempfile:...>, :head=>"..."}
-      yield "event: message
-data: #{ { status: 'Processing image: ' + image_file[:filename].to_s }.to_json }
-
-"
-      sleep 0.5 # Simulate work
+module SiftService
+  # Initiates the analysis by processing text and/or image input,
+  # then calls the AIService to generate a streamed response.
+  #
+  # @param text [String, nil] User-provided text.
+  # @param image_file [Hash, nil] Sinatra's file upload hash for an image.
+  # @param report_type [String] The type of report to generate.
+  # @param selected_model_id [String] The ID of the AI model to use.
+  # @param model_config_params [Hash] Configuration parameters for the AI model.
+  # @param block [Proc] The block to yield SSE chunks to, passed from Sinatra stream.
+  def self.initiate_analysis(text: nil, image_file: nil, report_type:, selected_model_id:, model_config_params:, &block)
+    unless block_given?
+      # LOGGER.error "SiftService: No block provided for streaming."
+      puts "SiftService: No block provided for streaming."
+      # In a real app, you might raise an error or handle this more gracefully.
+      return
     end
 
-    if text
-      yield "event: message
-data: #{ { status: 'Processing text: ' + text[0..30] + "..." }.to_json }
+    # LOGGER.info "SiftService: Initiating analysis with report_type: #{report_type}, model: #{selected_model_id}"
+    # LOGGER.debug "SiftService: Text provided: #{!text.nil? && !text.empty?}"
+    # LOGGER.debug "SiftService: Image file provided: #{!image_file.nil?}"
 
-"
-      sleep 0.5 # Simulate work
-    end
+    service_args = {
+      user_input_text: text, # AIService expects :user_input_text
+      report_type: report_type,
+      selected_model_id: selected_model_id,
+      model_config_params: model_config_params,
+      # chat_history could be another parameter if needed
+    }
 
-    yield "event: message
-data: #{ { status: 'Using model: ' + selected_model_id }.to_json }
+    begin
+      if image_file && image_file[:tempfile]
+        # LOGGER.info "SiftService: Processing uploaded image..."
+        ImageHandler.process_uploaded_image(image_file) do |processed_image_details|
+          # This block is executed if image processing is successful.
+          # The temporary file created by ImageHandler is available at processed_image_details[:file_path]
+          # and will be cleaned up automatically after this block.
 
-"
-    sleep 0.5
+          # LOGGER.info "SiftService: Image processed successfully. Path: #{processed_image_details[:file_path]}"
+          service_args[:image_file_details] = processed_image_details
 
-    # Simulate streaming of analysis results
-    5.times do |i|
-      yield "event: data_chunk
-data: #{ { chunk: i + 1, content: "This is chunk number #{i + 1} of the analysis." }.to_json }
+          # Call AI service from within the block to ensure temp file is still valid
+          AIService.generate_sift_stream(**service_args, &block)
+        end
+      else
+        # No image or invalid image_file hash, proceed without image details
+        # LOGGER.info "SiftService: No image provided or image_file data incomplete."
+        service_args[:image_file_details] = nil
+        AIService.generate_sift_stream(**service_args, &block)
+      end
+    rescue StandardError => e
+      # LOGGER.error "SiftService: Error during analysis initiation: #{e.class.name} - #{e.message}"
+      # LOGGER.error e.backtrace.join("
+  ")
+      # Yield a generic error to the client if one hasn't been yielded by AIService already
+      # This is a fallback. AIService should ideally handle its own errors and stream them.
+      error_json = { error: "An unexpected error occurred in SiftService: #{e.message}", type: e.class.name }.to_json
+      block.call("event: error
+data: #{error_json}
 
-"
-      sleep 0.3 # Simulate delay between chunks
-    end
-
-    yield "event: analysis_complete
-data: #{ { status: 'Analysis finished.', report_summary: 'A full report would be generated here.' }.to_json }
-
-"
-  rescue StandardError => e
-    # In case of an error within the service, yield an error event
-    error_message = "Error during SIFT analysis: #{e.message}"
-    puts "Error in SiftService: #{error_message}" # Log to server console
-    puts e.backtrace.join("
 ")
-    yield "event: error
-data: #{ { message: error_message, details: e.class.name }.to_json }
-
-"
+    end
   end
 end


### PR DESCRIPTION
This commit introduces a comprehensive solution for processing user-uploaded images in the Sinatra application, ensuring they are reliably passed to the `ruby_llm` gem.

Key changes:

1.  **`ImageHandler.process_uploaded_image` (in `sift_backend/lib/image_handler.rb`):**
    *   A new method `process_uploaded_image` is implemented to handle Sinatra's file upload parameters (specifically `params['userImageFile']`).
    *   It validates the input, ensuring a valid `Tempfile` object, MIME type, and filename are present.
    *   The core strategy involves copying the content of the uploaded `Tempfile` to a new, uniquely named temporary file in `Dir.tmpdir`. This ensures the file persists throughout its use by `ruby_llm`, regardless of `Tempfile`'s own lifecycle.
    *   The method primarily uses a block pattern: it yields a hash `{ file_path:, original_mime_type: }` to the block and guarantees cleanup of the new temporary file via an `ensure` clause after the block executes. This is the recommended way to use the method.
    *   If called without a block, it returns the hash, but the caller then becomes responsible for file cleanup.
    *   The old `process_image` method has been removed.

2.  **`SiftService.initiate_analysis` (in `sift_backend/services/sift_service.rb`):**
    *   This service is updated to utilize the new `ImageHandler.process_uploaded_image` method using its block pattern.
    *   If an image is provided, `ImageHandler` processes it, and the resulting `file_path` and `original_mime_type` are passed to `AIService.generate_sift_stream`.
    *   The service now correctly relays all necessary parameters, including the SSE block, from the Sinatra route to `AIService`.
    *   The previous mock streaming logic has been replaced with the actual call to `AIService`.

3.  **`AIService.generate_sift_stream` (in `sift_backend/services/ai_service.rb`):**
    *   This service is simplified. It no longer calls `ImageHandler` directly for processing.
    *   It now expects `image_file_details` to contain a `:file_path` that is already processed and valid for the duration of the `ruby_llm` call.
    *   The `image_path` used for `ruby_llm`'s `with:` option is taken directly from `image_file_details[:file_path]`.

This implementation addresses the requirements for safely obtaining a usable file path from Sinatra's `Tempfile`, managing file lifetimes correctly for `ruby_llm` integration, and providing the necessary details in the specified return format. The "copy to a new temp location and clean up" strategy is employed for robustness.