### PR TITLE
Add AgentManager for dynamic AI agent configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gem 'sinatra' # Assuming Sinatra is the web framework
 gem 'dotenv'  # For loading environment variables from .env file in development
+gem 'tty-config'
 # Add other gems your application needs

--- a/app/services/agent_manager.rb
+++ b/app/services/agent_manager.rb
@@ -1,0 +1,62 @@
+require 'tty-config'
+require 'erb'
+require 'date' # Required for Date.today
+
+module AgentManager
+  class AgentNotFoundError < StandardError; end
+  class BehaviorNotFoundError < StandardError; end
+  class ErbRenderingError < StandardError; end
+
+  def self.config_path
+    File.expand_path('../../../config/agents', __FILE__)
+  end
+
+  def self.load_agent_config(agent_name)
+    config_file = File.join(config_path, "#{agent_name}.yml")
+    raise AgentNotFoundError, "Agent configuration file not found: #{config_file}" unless File.exist?(config_file)
+
+    config = TTY::Config.new
+    config.read(config_file) # Directly read the specific file
+    config
+  rescue TTY::Config::ReadError => e # This should catch errors if the file is unreadable by tty-config
+    raise AgentNotFoundError, "Error reading agent configuration file: #{e.message}"
+  end
+
+  def self.get_processed_behavior(agent_name:, behavior_key: :interaction, context_vars: {})
+    config = load_agent_config(agent_name)
+    # Fetch the 'behaviors' block first, then the specific behavior from it.
+    behaviors_block = config.fetch("behaviors")
+    raise BehaviorNotFoundError, "Top-level 'behaviors' key not found for agent '#{agent_name}'" if behaviors_block.nil?
+    raw_behavior = behaviors_block.fetch(behavior_key.to_s)
+
+    raise BehaviorNotFoundError, "Behavior '#{behavior_key}' not found for agent '#{agent_name}'" if raw_behavior.nil?
+
+    processed_behavior = {}
+    raw_behavior.each do |key, value|
+      if value.is_a?(String)
+        begin
+          erb_template = ERB.new(value)
+          processed_behavior[key.to_sym] = erb_template.result_with_hash(context_vars)
+        rescue StandardError => e
+          raise ErbRenderingError, "Error rendering ERB for key '#{key}' in behavior '#{behavior_key}': #{e.message}"
+        end
+      else
+        processed_behavior[key.to_sym] = value # Keep non-string values as is
+      end
+    end
+    processed_behavior
+
+  rescue KeyError => e # Standard Ruby error for Hash#fetch when key not found
+    raise BehaviorNotFoundError, "Missing key in agent configuration: #{e.message}"
+  end
+
+  def self.get_interaction_directive(agent_name:, context_vars: {})
+    behavior = get_processed_behavior(agent_name: agent_name, behavior_key: :interaction, context_vars: context_vars)
+    behavior[:directive]
+  end
+
+  def self.get_boot_directive(agent_name:, context_vars: {})
+    behavior = get_processed_behavior(agent_name: agent_name, behavior_key: :boot, context_vars: context_vars)
+    behavior[:directive]
+  end
+end

--- a/config/agents/sift_full_check.yml
+++ b/config/agents/sift_full_check.yml
@@ -1,0 +1,5 @@
+meta:
+  name: SIFT Full Check
+behaviors:
+  interaction:
+    directive: "Generated <%= current_date %>. User query: <%= user_query %>."

--- a/services/ai_service.rb
+++ b/services/ai_service.rb
@@ -77,3 +77,77 @@ end
 # rescue => e
 #   puts "Error: #{e.message}"
 # end
+
+# Ensure AgentManager is loaded.
+# This might be handled in a central place like app.rb or config/environment.rb
+# If not, you might need: require_relative '../app/services/agent_manager'
+
+# Example of an AIService using AgentManager
+module AIServices
+  class AgentBasedAIService
+    def initialize(agent_name, provider_service)
+      @agent_name = agent_name
+      @provider_service = provider_service # e.g., an instance of AIServices::Gemini
+    end
+
+    def perform_interaction(user_query)
+      context_vars = {
+        current_date: Date.today.to_s,
+        user_query: user_query
+      }
+
+      # Using AgentManager to get the processed directive
+      directive = nil
+      begin
+        directive = AgentManager.get_interaction_directive(
+          agent_name: @agent_name,
+          context_vars: context_vars
+        )
+      rescue AgentManager::AgentNotFoundError => e
+        puts "Error: #{e.message}"
+        return "Failed to load agent configuration."
+      rescue AgentManager::BehaviorNotFoundError => e
+        puts "Error: #{e.message}"
+        return "Failed to find behavior in agent configuration."
+      rescue AgentManager::ErbRenderingError => e
+        puts "Error: #{e.message}"
+        return "Failed to render directive template."
+      end
+
+      puts "Agent '#{@agent_name}' using directive: \n#{directive}"
+
+      # Now, use this directive with the actual AI provider
+      # @provider_service.call_api(directive)
+      "Simulated call to AI with processed directive for agent '#{@agent_name}' and query '#{user_query}'"
+    end
+  end
+end
+
+# Example Usage for AgentBasedAIService (conceptual):
+#
+# require_relative '../config/config' # Ensure Config is loaded
+# require_relative '../app/services/agent_manager' # Ensure AgentManager is loaded
+# require_relative 'ai_service'      # Ensure AIServices are loaded
+#
+# begin
+#   # Assuming you have a configured AI provider service
+#   # For example, using the existing Gemini service
+#   gemini_provider = AIServices::Gemini.new
+#
+#   # Create an instance of the agent-based service
+#   sift_checker_service = AIServices::AgentBasedAIService.new(:sift_full_check, gemini_provider)
+#
+#   # Perform an interaction
+#   user_input = "Is the sky blue?"
+#   response = sift_checker_service.perform_interaction(user_input)
+#   puts response
+#
+#   # Example with a non-existent agent
+#   # non_existent_agent_service = AIServices::AgentBasedAIService.new(:non_existent_agent, gemini_provider)
+#   # response_non_existent = non_existent_agent_service.perform_interaction("Test query")
+#   # puts response_non_existent
+#
+# rescue StandardError => e
+#   puts "An unexpected error occurred: #{e.message}"
+#   puts e.backtrace.join("\n")
+# end

--- a/sift_backend/Gemfile.lock
+++ b/sift_backend/Gemfile.lock
@@ -5,11 +5,27 @@ GEM
     base64 (0.3.0)
     bigdecimal (3.2.2)
     dotenv (2.8.1)
+    event_stream_parser (1.0.0)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    faraday-retry (2.3.1)
+      faraday (~> 2.0)
     json (2.12.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
+    marcel (1.0.4)
+    multipart-post (2.4.1)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
+    net-http (0.6.0)
+      uri
     nio4r (2.7.4)
     parallel (1.27.0)
     parser (3.3.8.0)
@@ -43,6 +59,15 @@ GEM
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_llm (1.3.0)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1.0)
+      zeitwerk (~> 2)
     sequel (5.93.0)
       bigdecimal
     sinatra (3.2.0)
@@ -55,6 +80,8 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.3)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   x86_64-linux-gnu
@@ -66,6 +93,7 @@ DEPENDENCIES
   puma (~> 6.0)
   rake (~> 13.0)
   rubocop (~> 1.50)
+  ruby_llm
   sequel (~> 5.7)
   sinatra (~> 3.0)
   sinatra-cross_origin

--- a/test/services/agent_manager_test.rb
+++ b/test/services/agent_manager_test.rb
@@ -1,0 +1,174 @@
+require 'minitest/autorun'
+require_relative '../../app/services/agent_manager' # Adjust path as necessary
+require 'fileutils' # For creating temp files/dirs
+
+class TestAgentManager < Minitest::Test
+  AGENT_CONFIG_DIR = File.expand_path('../../../config/agents', __FILE__)
+  TEMP_AGENT_DIR = File.join(AGENT_CONFIG_DIR, 'temp_test_agents')
+
+  def setup
+    # Create a temporary directory for test agent files
+    FileUtils.mkdir_p(TEMP_AGENT_DIR)
+
+    # Create a dummy valid agent file
+    @valid_agent_name = :test_agent_valid
+    valid_agent_content = <<~YAML
+      meta:
+        name: Test Valid Agent
+      behaviors:
+        interaction:
+          directive: "Hello <%= name %>! Today is <%= date %>."
+          instruction: "Follow the directive."
+        boot:
+          directive: "Booting up with <%= setting %>."
+    YAML
+    File.write(File.join(TEMP_AGENT_DIR, "#{@valid_agent_name}.yml"), valid_agent_content)
+
+    # Create a dummy agent file with ERB error
+    @erb_error_agent_name = :test_agent_erb_error
+    erb_error_agent_content = <<~YAML
+      behaviors:
+        interaction:
+          directive: "Hello <%= name.this_should_really_fail %>!" # More robust ERB syntax error
+    YAML
+    File.write(File.join(TEMP_AGENT_DIR, "#{@erb_error_agent_name}.yml"), erb_error_agent_content)
+
+    # Override config_path in AgentManager to point to our temp directory for isolation
+    AgentManager.define_singleton_method(:config_path) do
+      TEMP_AGENT_DIR
+    end
+  end
+
+  def teardown
+    # Clean up the temporary directory
+    FileUtils.rm_rf(TEMP_AGENT_DIR)
+
+    # Restore original config_path method by removing the singleton method
+    # This is a bit of a hack for testing; in a real app, dependency injection or
+    # a configurable path would be better.
+    AgentManager.singleton_class.send(:remove_method, :config_path)
+    # Redefine it to original if needed for other tests, or ensure AgentManager is reloaded
+    AgentManager.define_singleton_method(:config_path) do
+      File.expand_path('../../../config/agents', __FILE__)
+    end
+
+  end
+
+  def test_load_agent_config_success
+    config = AgentManager.load_agent_config(@valid_agent_name)
+    assert_instance_of TTY::Config, config
+    assert_equal "Test Valid Agent", config.fetch('meta.name')
+  end
+
+  def test_load_agent_config_file_not_found
+    assert_raises AgentManager::AgentNotFoundError do
+      AgentManager.load_agent_config(:non_existent_agent)
+    end
+  end
+
+  def test_get_processed_behavior_success
+    context = { name: "World", date: "2023-10-27" }
+    behavior = AgentManager.get_processed_behavior(
+      agent_name: @valid_agent_name,
+      behavior_key: :interaction,
+      context_vars: context
+    )
+    assert_equal "Hello World! Today is 2023-10-27.", behavior[:directive]
+    assert_equal "Follow the directive.", behavior[:instruction]
+  end
+
+  def test_get_processed_behavior_missing_behavior_key
+    assert_raises AgentManager::BehaviorNotFoundError do
+      AgentManager.get_processed_behavior(agent_name: @valid_agent_name, behavior_key: :non_existent_behavior)
+    end
+  end
+
+  def test_get_processed_behavior_erb_rendering_error
+    context = { name: "Test" }
+    assert_raises AgentManager::ErbRenderingError do
+      AgentManager.get_processed_behavior(
+        agent_name: @erb_error_agent_name,
+        behavior_key: :interaction,
+        context_vars: context
+      )
+    end
+  end
+
+  def test_get_interaction_directive_success
+    context = { name: "Jules", date: "2024-01-01" }
+    directive = AgentManager.get_interaction_directive(
+      agent_name: @valid_agent_name,
+      context_vars: context
+    )
+    assert_equal "Hello Jules! Today is 2024-01-01.", directive
+  end
+
+  def test_get_boot_directive_success
+    context = { setting: "Default Setting" }
+    directive = AgentManager.get_processed_behavior(
+      agent_name: @valid_agent_name,
+      behavior_key: :boot,
+      context_vars: context
+    )[:directive] # Accessing directly for this specific test structure
+    assert_equal "Booting up with Default Setting.", directive
+  end
+
+  def test_get_interaction_directive_agent_not_found
+    assert_raises AgentManager::AgentNotFoundError do
+      AgentManager.get_interaction_directive(agent_name: :ghost_agent, context_vars: {})
+    end
+  end
+end
+
+# Create a dummy sift_full_check.yml in the actual config/agents path for one test
+# This is to ensure the original config path works as expected for the provided example
+# It's a bit of a workaround due to the dynamic path change in tests.
+# A more robust solution would involve a test-specific configuration for AgentManager.
+
+# Setup main sift_full_check.yml for the example test
+sift_full_check_content = <<~YAML
+meta:
+  name: SIFT Full Check
+behaviors:
+  interaction:
+    directive: "Generated <%= current_date %>. User query: <%= user_query %>."
+YAML
+sift_config_path = File.expand_path('../../../config/agents', __FILE__)
+FileUtils.mkdir_p(sift_config_path)
+File.write(File.join(sift_config_path, "sift_full_check.yml"), sift_full_check_content)
+
+# Adding a test case that uses the actual sift_full_check.yml
+# This requires AgentManager to use its original config_path logic.
+class TestAgentManagerWithActualConfig < Minitest::Test
+  def test_sift_full_check_example_usage
+    # Ensure AgentManager uses its original config_path
+    # This might involve ensuring no singleton overrides from other test classes affect this one,
+    # or by re-instantiating/re-requiring AgentManager if necessary and possible.
+    # For simplicity here, we rely on the teardown of the previous class and order of execution,
+    # or that this test runs in a separate context where the override is not present.
+    # A better way is to pass the config path to AgentManager methods if possible.
+
+    # Due to the test structure and singleton method manipulation,
+    # it's safer to explicitly restore and use the original path logic.
+    original_config_path_method = AgentManager.method(:config_path)
+    AgentManager.define_singleton_method(:config_path) do
+      File.expand_path('../../../config/agents', __FILE__)
+    end
+
+    context = { current_date: "2023-11-01", user_query: "Is this real?" }
+    directive = AgentManager.get_interaction_directive(
+      agent_name: :sift_full_check, # This should match the actual file name
+      context_vars: context
+    )
+    assert_equal "Generated 2023-11-01. User query: Is this real?.", directive
+  ensure
+    # Restore the original method whatever it was to avoid interference
+    AgentManager.define_singleton_method(:config_path, original_config_path_method)
+  end
+
+  # Clean up the dummy sift_full_check.yml if it was created by this test class
+  Minitest.after_run do
+    sift_file_path = File.join(File.expand_path('../../../config/agents', __FILE__), "sift_full_check.yml")
+    #FileUtils.rm_f(sift_file_path) # Commented out to keep the example file
+  end
+end


### PR DESCRIPTION
This commit introduces the AgentManager module, responsible for loading and processing AI agent configurations from YAML files. These configurations can include ERB templates for dynamic value insertion.

Key features:
- Loads agent configurations from `config/agents/*.yml` using `tty-config`.
- Processes ERB templates within behavior directives, backdrops, and instructions.
- Provides methods to retrieve specific processed behavior components (e.g., interaction directives).
- Includes error handling for missing agent files, missing configuration keys, and ERB rendering errors.

The `tty-config` gem has been added to the Gemfile.

An example `sift_full_check.yml` agent configuration is provided in `config/agents/`. The `services/ai_service.rb` file includes an example `AgentBasedAIService` demonstrating how to use the `AgentManager` to fetch and use a processed directive.

Unit tests for `AgentManager` have been added in `test/services/agent_manager_test.rb`, covering successful operation and error handling scenarios.