### PR TITLE
feat: Add apiClient for SIFT analysis initiation

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -9,3 +9,6 @@ export const EMOJI_VERDICT = "🏆";
 export const EMOJI_TIP = "💡";
 
 export const SIFT_ICON = "🔍"; // Magnifying glass for SIFT
+
+// API Configuration
+export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:9292/api';

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -1,0 +1,55 @@
+import { ReportType } from '../types';
+import { API_BASE_URL } from '../constants';
+
+export interface InitiateSiftAnalysisParams {
+  userInputText?: string;
+  userImageFile?: File;
+  reportType: ReportType;
+  selectedModelId: string;
+  modelConfigParams: Record<string, any>;
+}
+
+export interface InitiateSiftAnalysisResponse {
+  streamUrl: string;
+}
+
+export const initiateSiftAnalysis = async (
+  params: InitiateSiftAnalysisParams
+): Promise<string> => {
+  const formData = new FormData();
+
+  if (params.userInputText) {
+    formData.append('userInputText', params.userInputText);
+  }
+  if (params.userImageFile) {
+    formData.append('userImageFile', params.userImageFile);
+  }
+  formData.append('reportType', params.reportType);
+  formData.append('selectedModelId', params.selectedModelId);
+  formData.append('modelConfigParams', JSON.stringify(params.modelConfigParams));
+
+  const response = await fetch(`${API_BASE_URL}/sift/initiate`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`API request failed with status ${response.status}: ${errorBody}`);
+  }
+
+  try {
+    const data: InitiateSiftAnalysisResponse = await response.json();
+    if (data && data.streamUrl) {
+      return data.streamUrl;
+    } else {
+      throw new Error('API response did not include a streamUrl.');
+    }
+  } catch (e) {
+    // Handle cases where response.json() fails or data.streamUrl is not found
+    if (e instanceof Error) {
+      throw new Error(`Failed to parse API response or missing streamUrl: ${e.message}`);
+    }
+    throw new Error('Failed to parse API response or missing streamUrl due to an unknown error.');
+  }
+};


### PR DESCRIPTION
Creates a new `apiClient.ts` service with the `initiateSiftAnalysis` function.

This function is responsible for:
- Accepting your input (text or image), report type, model ID, and model configuration parameters.
- Constructing a FormData object with these parameters.
- Making a POST request to the `/api/sift/initiate` backend endpoint.
- Expecting a JSON response from the backend containing a `streamUrl` for Server-Sent Events.
- Returning this `streamUrl` to the caller.

Also adds an `API_BASE_URL` constant in `constants.ts` to configure the target API endpoint, defaulting to `http://localhost:9292/api`.